### PR TITLE
Fixed type

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ if your system is RedHat, run the commands below.
 ```
 $ cd RedHat
 $ chmod +x * 
-$ ./opencv-latest.sh
+$ ./opencv_latest.sh
 ```
 
 


### PR DESCRIPTION
In the README, the filename didn't match the actual filename.
Changed `opencv-latest.sh` to `opencv_latest.sh`
